### PR TITLE
- prepared to build a package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,19 @@
+PREFIXBIN=/usr/bin
+SHAREDIR=/usr/share
+NAME=altbooster
+
+install: install-data install-bin
+
+install-data:
+	install -d $(SHAREDIR)/$(NAME)
+	install -d $(SHAREDIR)/applications
+	install -d $(SHAREDIR)/icons/hicolor/512x512/apps
+	install -d $(PREFIXBIN)
+	cp -a $(NAME).desktop $(SHAREDIR)/applications
+	cp -a icons/$(NAME).svg $(SHAREDIR)/icons/hicolor/512x512/apps
+	cp -a src/*.py $(SHAREDIR)/$(NAME)
+	cp -p -r src/builtin_actions src/modules src/system src/ui $(SHAREDIR)/$(NAME) 
+
+install-bin:
+	install -Dm755 $(NAME) $(PREFIXBIN)/$(NAME)
+	

--- a/altbooster
+++ b/altbooster
@@ -1,0 +1,3 @@
+#!/bin/bash
+exec python3 /usr/share/altbooster/main.py "$@"
+

--- a/altbooster.desktop
+++ b/altbooster.desktop
@@ -1,0 +1,12 @@
+[Desktop Entry]
+Name=ALT Booster
+GenericName=System Maintenance
+Comment=Утилита обслуживания системы ALT Linux
+Exec=altbooster
+Icon=altbooster
+Terminal=false
+Type=Application
+Categories=System;Settings;
+Keywords=system;maintenance;clean;btrfs;trim;apt;flatpak;
+StartupNotify=true
+StartupWMClass=ru.altbooster.app

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,19 +1,27 @@
+[build-system]
+requires = ['setuptools']
+build-backend = 'setuptools.build_meta'
+
 [project]
 name = "altbooster"
-version = "5.6"
+version = "5.6.3"
 description = "Утилита настройки и обслуживания ALT Linux"
 readme = "README.md"
-license = { text = "MIT" }
+license = "MIT"
 authors = [{ name = "PLAFON" }]
 requires-python = ">=3.11"
-
-# Внешних Python-зависимостей нет — только GTK4/Adwaita через систему
-dependencies = []
 
 [project.urls]
 Homepage   = "https://github.com/plafonlinux/altbooster"
 Repository = "https://github.com/plafonlinux/altbooster"
 Issues     = "https://github.com/plafonlinux/altbooster/issues"
+
+[tool.setuptools.packages.find]
+include = ['altbooster*']
+
+[tool.setuptools.package-data]
+"altbooster.modules" = ['*.json']
+"altbooster.system" = ['*.tmp']
 
 [tool.ruff]
 line-length = 100
@@ -24,4 +32,4 @@ select = ["E", "F", "W", "I"]   # pycodestyle + pyflakes + isort
 ignore = ["E501"]                # длинные строки в bash-командах — допустимо
 
 [tool.ruff.lint.per-file-ignores]
-"src/config.py" = ["E501"]      # bash-команды в APPS неизбежно длинные
+"altbooster/config.py" = ["E501"]      # bash-команды в APPS неизбежно длинные


### PR DESCRIPTION
Добрый день.

Если позволите, то по порядку:

Я поправил Вам pyproject.toml, что бы он паковался через setuptools, однако каталог исходников должен быть не src, а altbooster ну да бог с ним, так как при сборке пакета он сам всебя ищет в зависимостях... отключение автопровайдеринга и/или автоreq не помогает, приложение крашится при старте, так как не может открыть файлы... возможно это связано что некорректно обрабатываются именно питоновыские пути, так как сетаптул по хорошему собирает именно в питоновские пути

Я сделал простенький Makefile и собрал его через make, файлы я тоже приложил, однако все равно столкнулся с
```sh
Следующие пакеты имеют неудовлетворенные зависимости:
  plafon-altbooster: Depends: python3(config) (< 0)
                     Depends: python3(ui) (< 0)
```

пришлось выключить AutoReq: nopython3 что на мой взгляд плохо, так как при установке на ту же KDE возможно будут проблемы.

Тестовое задание я сделал, но нужно проверять
https://packages.altlinux.org/ru/tasks/409776/

однако, я всеж считаю, что что-то не так у Вас в коде... что даже при размещении по путям /use/share/alt...  он ругается такого быть не должно, в моем понимании..

он не должен искать зависимость в самом себе

P.S. и чисто мое мнение, если вы используете pyproject.toml, то мне кажется лучше использовать его в связке с meson а не с setuptool, чтоб можно было разместить по путям /usr/share .. как впрочем вы изначально и задумали.